### PR TITLE
Feature: Doors

### DIFF
--- a/lib/gatekeeper.ex
+++ b/lib/gatekeeper.ex
@@ -12,7 +12,7 @@ defmodule Gatekeeper do
       # Start the Ecto repository
       worker(Gatekeeper.Repo, []),
       # Here you could define other workers and supervisors as children
-      worker(Gatekeeper.Door, []),
+      worker(Gatekeeper.DoorInterface, []),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/gatekeeper/door_interface.ex
+++ b/lib/gatekeeper/door_interface.ex
@@ -1,4 +1,4 @@
-defmodule Gatekeeper.Door do
+defmodule Gatekeeper.DoorInterface do
   require Logger
 
   use GenServer

--- a/priv/repo/migrations/20151107191438_create_door.exs
+++ b/priv/repo/migrations/20151107191438_create_door.exs
@@ -1,0 +1,12 @@
+defmodule Gatekeeper.Repo.Migrations.CreateDoor do
+  use Ecto.Migration
+
+  def change do
+    create table(:doors) do
+      add :name, :string
+
+      timestamps
+    end
+
+  end
+end

--- a/priv/repo/migrations/20151107191807_create_door_group.exs
+++ b/priv/repo/migrations/20151107191807_create_door_group.exs
@@ -1,0 +1,12 @@
+defmodule Gatekeeper.Repo.Migrations.CreateDoorGroup do
+  use Ecto.Migration
+
+  def change do
+    create table(:door_groups) do
+      add :name, :string
+
+      timestamps
+    end
+
+  end
+end

--- a/priv/repo/migrations/20151107194246_create_door_group_doors.exs
+++ b/priv/repo/migrations/20151107194246_create_door_group_doors.exs
@@ -1,0 +1,13 @@
+defmodule Gatekeeper.Repo.Migrations.CreateDoorGroupDoors do
+  use Ecto.Migration
+
+  def change do
+    create table(:door_group_doors) do
+      add :door_group_id, :integer
+      add :door_id, :integer
+
+      timestamps
+    end
+
+  end
+end

--- a/priv/repo/migrations/20151107195518_create_door_group_member.exs
+++ b/priv/repo/migrations/20151107195518_create_door_group_member.exs
@@ -1,0 +1,13 @@
+defmodule Gatekeeper.Repo.Migrations.CreateDoorGroupMember do
+  use Ecto.Migration
+
+  def change do
+    create table(:door_group_members) do
+      add :door_group_id, :integer
+      add :member_id, :integer
+
+      timestamps
+    end
+
+  end
+end

--- a/priv/repo/migrations/20151108223926_create_door_group_company.exs
+++ b/priv/repo/migrations/20151108223926_create_door_group_company.exs
@@ -1,0 +1,13 @@
+defmodule Gatekeeper.Repo.Migrations.CreateDoorGroupCompany do
+  use Ecto.Migration
+
+  def change do
+    create table(:door_group_companies) do
+      add :door_group_id, :integer
+      add :company_id, :integer
+
+      timestamps
+    end
+
+  end
+end

--- a/test/controllers/company_controller_test.exs
+++ b/test/controllers/company_controller_test.exs
@@ -85,7 +85,6 @@ defmodule Gatekeeper.CompanyControllerTest do
     assert [] == Enum.map(company.door_groups, &(&1.id))
   end
 
-
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     company = Repo.insert! %Company{}
     conn = put conn, company_path(conn, :update, company), company: @invalid_attrs

--- a/test/controllers/company_controller_test.exs
+++ b/test/controllers/company_controller_test.exs
@@ -73,6 +73,19 @@ defmodule Gatekeeper.CompanyControllerTest do
     assert [door_group.id] == Enum.map(company.door_groups, &(&1.id))
   end
 
+  test "removes unchecked associated door groups from a company", %{conn: conn} do
+    door_group = create_door_group
+    company = create_company
+    door_group_company = Repo.insert! %Gatekeeper.DoorGroupCompany{company_id: company.id, door_group_id: door_group.id}
+
+    conn = put conn, company_path(conn, :update, company), company: Dict.merge(@valid_attrs, id: company.id)
+    assert redirected_to(conn) == company_path(conn, :show, company)
+    company = Repo.get!(Company, company.id) |> Repo.preload :door_groups
+    assert company
+    assert [] == Enum.map(company.door_groups, &(&1.id))
+  end
+
+
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     company = Repo.insert! %Company{}
     conn = put conn, company_path(conn, :update, company), company: @invalid_attrs

--- a/test/controllers/door_controller_test.exs
+++ b/test/controllers/door_controller_test.exs
@@ -1,7 +1,11 @@
 defmodule Gatekeeper.DoorControllerTest do
   use Gatekeeper.ConnCase
 
+  import Gatekeeper.Factory
+
   alias Gatekeeper.Door
+  alias Gatekeeper.DoorGroup
+
   @valid_attrs %{name: "some content"}
   @invalid_attrs %{}
 
@@ -54,6 +58,33 @@ defmodule Gatekeeper.DoorControllerTest do
     conn = put conn, door_path(conn, :update, door), door: @valid_attrs
     assert redirected_to(conn) == door_path(conn, :show, door)
     assert Repo.get_by(Door, @valid_attrs)
+  end
+
+  test "updates door group with associated doors and redirects when data is valid", %{conn: conn} do
+    door_group = create_door_group
+    door = create_door
+    # We can't dynamically construct a map with a variable without this
+    # See: http://stackoverflow.com/questions/29837103/how-to-put-key-value-pair-into-map-with-variable-key-name
+    # "Note that variables cannot be used as keys to add items to a map:"
+    # See: http://elixir-lang.org/getting-started/maps-and-dicts.html#maps
+    doors_param = Map.put(%{}, "#{door.id}", "on")
+    conn = put conn, door_group_path(conn, :update, door_group), door_group: Dict.merge(@valid_attrs, %{doors: doors_param })
+    assert redirected_to(conn) == door_group_path(conn, :show, door_group)
+    door_group = Repo.get_by(DoorGroup, @valid_attrs) |> Repo.preload :doors
+    assert door_group
+    assert [door.id] == Enum.map(door_group.doors, &(&1.id))
+  end
+
+  test "removes unchecked associated door groups from a company", %{conn: conn} do
+    door_group = create_door_group
+    door = create_door
+    Repo.insert! %Gatekeeper.DoorGroupDoor{door_id: door.id, door_group_id: door_group.id}
+
+    conn = put conn, door_group_path(conn, :update, door_group), door_group: Dict.merge(@valid_attrs, id: door_group.id)
+    assert redirected_to(conn) == door_group_path(conn, :show, door_group)
+    door_group = Repo.get!(DoorGroup, door_group.id) |> Repo.preload :doors
+    assert door_group
+    assert [] == Enum.map(door_group.doors, &(&1.id))
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do

--- a/test/controllers/door_controller_test.exs
+++ b/test/controllers/door_controller_test.exs
@@ -1,0 +1,71 @@
+defmodule Gatekeeper.DoorControllerTest do
+  use Gatekeeper.ConnCase
+
+  alias Gatekeeper.Door
+  @valid_attrs %{name: "some content"}
+  @invalid_attrs %{}
+
+  setup do
+    conn = conn()
+    {:ok, conn: conn}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, door_path(conn, :index)
+    assert html_response(conn, 200) =~ "Listing doors"
+  end
+
+  test "renders form for new resources", %{conn: conn} do
+    conn = get conn, door_path(conn, :new)
+    assert html_response(conn, 200) =~ "New door"
+  end
+
+  test "creates resource and redirects when data is valid", %{conn: conn} do
+    conn = post conn, door_path(conn, :create), door: @valid_attrs
+    assert redirected_to(conn) == door_path(conn, :index)
+    assert Repo.get_by(Door, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, door_path(conn, :create), door: @invalid_attrs
+    assert html_response(conn, 200) =~ "New door"
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    door = Repo.insert! %Door{}
+    conn = get conn, door_path(conn, :show, door)
+    assert html_response(conn, 200) =~ "Show door"
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_raise Ecto.NoResultsError, fn ->
+      get conn, door_path(conn, :show, -1)
+    end
+  end
+
+  test "renders form for editing chosen resource", %{conn: conn} do
+    door = Repo.insert! %Door{}
+    conn = get conn, door_path(conn, :edit, door)
+    assert html_response(conn, 200) =~ "Edit door"
+  end
+
+  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+    door = Repo.insert! %Door{}
+    conn = put conn, door_path(conn, :update, door), door: @valid_attrs
+    assert redirected_to(conn) == door_path(conn, :show, door)
+    assert Repo.get_by(Door, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    door = Repo.insert! %Door{}
+    conn = put conn, door_path(conn, :update, door), door: @invalid_attrs
+    assert html_response(conn, 200) =~ "Edit door"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    door = Repo.insert! %Door{}
+    conn = delete conn, door_path(conn, :delete, door)
+    assert redirected_to(conn) == door_path(conn, :index)
+    refute Repo.get(Door, door.id)
+  end
+end

--- a/test/controllers/door_group_controller_test.exs
+++ b/test/controllers/door_group_controller_test.exs
@@ -1,0 +1,71 @@
+defmodule Gatekeeper.DoorGroupControllerTest do
+  use Gatekeeper.ConnCase
+
+  alias Gatekeeper.DoorGroup
+  @valid_attrs %{name: "some content"}
+  @invalid_attrs %{}
+
+  setup do
+    conn = conn()
+    {:ok, conn: conn}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, door_group_path(conn, :index)
+    assert html_response(conn, 200) =~ "Listing door groups"
+  end
+
+  test "renders form for new resources", %{conn: conn} do
+    conn = get conn, door_group_path(conn, :new)
+    assert html_response(conn, 200) =~ "New door group"
+  end
+
+  test "creates resource and redirects when data is valid", %{conn: conn} do
+    conn = post conn, door_group_path(conn, :create), door_group: @valid_attrs
+    assert redirected_to(conn) == door_group_path(conn, :index)
+    assert Repo.get_by(DoorGroup, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, door_group_path(conn, :create), door_group: @invalid_attrs
+    assert html_response(conn, 200) =~ "New door group"
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    door_group = Repo.insert! %DoorGroup{}
+    conn = get conn, door_group_path(conn, :show, door_group)
+    assert html_response(conn, 200) =~ "Show door group"
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_raise Ecto.NoResultsError, fn ->
+      get conn, door_group_path(conn, :show, -1)
+    end
+  end
+
+  test "renders form for editing chosen resource", %{conn: conn} do
+    door_group = Repo.insert! %DoorGroup{}
+    conn = get conn, door_group_path(conn, :edit, door_group)
+    assert html_response(conn, 200) =~ "Edit door group"
+  end
+
+  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+    door_group = Repo.insert! %DoorGroup{}
+    conn = put conn, door_group_path(conn, :update, door_group), door_group: @valid_attrs
+    assert redirected_to(conn) == door_group_path(conn, :show, door_group)
+    assert Repo.get_by(DoorGroup, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    door_group = Repo.insert! %DoorGroup{}
+    conn = put conn, door_group_path(conn, :update, door_group), door_group: @invalid_attrs
+    assert html_response(conn, 200) =~ "Edit door group"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    door_group = Repo.insert! %DoorGroup{}
+    conn = delete conn, door_group_path(conn, :delete, door_group)
+    assert redirected_to(conn) == door_group_path(conn, :index)
+    refute Repo.get(DoorGroup, door_group.id)
+  end
+end

--- a/test/controllers/door_group_controller_test.exs
+++ b/test/controllers/door_group_controller_test.exs
@@ -32,9 +32,9 @@ defmodule Gatekeeper.DoorGroupControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    door_group = Repo.insert! %DoorGroup{}
+    door_group = Repo.insert! %DoorGroup{name: "Test DG"}
     conn = get conn, door_group_path(conn, :show, door_group)
-    assert html_response(conn, 200) =~ "Show door group"
+    assert html_response(conn, 200) =~ "Door Group: #{door_group.name}"
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do

--- a/test/factory.exs
+++ b/test/factory.exs
@@ -1,0 +1,85 @@
+defmodule Gatekeeper.Factory do
+
+  alias Gatekeeper.Repo
+  alias Gatekeeper.Company
+  alias Gatekeeper.Member
+  alias Gatekeeper.RfidToken
+  alias Gatekeeper.Door
+  alias Gatekeeper.DoorGroup
+  alias Gatekeeper.DoorGroupDoor
+  alias Gatekeeper.DoorGroupMember
+  alias Gatekeeper.DoorGroupCompany
+
+  def create_company(params \\ %{}) do
+    default_params = %{
+      name: "Test Company",
+      join_date: :calendar.local_time(),
+      departure_date: nil,
+    }
+    params = Dict.merge(default_params, params)
+    changeset = Company.changeset(%Company{}, params)
+    {:ok, company} = Repo.insert(changeset)
+    company
+  end
+
+  def create_member(params \\ %{}) do
+    default_params = %{
+      name: "Test Member",
+      email: "test@example.com",
+      active: true,
+    }
+    # :company is a required parameter
+    default_params = Dict.merge(default_params, company_id: params[:company].id)
+
+    params = Dict.merge(default_params, params)
+    changeset = Member.changeset(%Member{}, params)
+    {:ok, member} = Repo.insert(changeset)
+
+    if params[:door_group] do
+      changeset = DoorGroupMember.changeset(%DoorGroupMember{}, %{member_id: member.id, door_group_id: params.door_group.id})
+      Repo.insert(changeset)
+    end
+
+    member
+  end
+
+  def create_rfid_token(params \\ %{}) do
+    default_params = %{
+      identifier: "abcd1234",
+      active: true,
+    }
+    # :member is a required parameter
+    default_params = Dict.merge(default_params, member_id: params[:member].id)
+
+    params = Dict.merge(default_params, params)
+    changeset = RfidToken.changeset(%RfidToken{}, params)
+    {:ok, rfid_token} = Repo.insert(changeset)
+    rfid_token
+  end
+
+  def create_door_group(params \\ %{}) do
+    default_params = %{
+      name: "Test Dooor Group",
+    }
+    params = Dict.merge(default_params, params)
+    changeset = DoorGroup.changeset(%DoorGroup{}, params)
+    {:ok, door_group} = Repo.insert(changeset)
+    door_group
+  end
+
+  def create_door(params \\ %{}) do
+    default_params = %{
+      name: "Test Door",
+    }
+    params = Dict.merge(default_params, params)
+    changeset = Door.changeset(%Door{}, params)
+    {:ok, door} = Repo.insert(changeset)
+
+    if params[:door_group] do
+      changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, %{door_id: door.id, door_group_id: params.door_group.id})
+      Repo.insert(changeset)
+    end
+
+    door
+  end
+end

--- a/test/factory.exs
+++ b/test/factory.exs
@@ -8,6 +8,7 @@ defmodule Gatekeeper.Factory do
   alias Gatekeeper.DoorGroup
   alias Gatekeeper.DoorGroupDoor
   alias Gatekeeper.DoorGroupMember
+  alias Gatekeeper.DoorGroupCompany
 
   def create_company(params \\ %{}) do
     default_params = %{
@@ -18,6 +19,12 @@ defmodule Gatekeeper.Factory do
     params = Dict.merge(default_params, params)
     changeset = Company.changeset(%Company{}, params)
     {:ok, company} = Repo.insert(changeset)
+
+    if params[:door_group] do
+      changeset = DoorGroupCompany.changeset(%DoorGroupCompany{}, %{company_id: company.id, door_group_id: params.door_group.id})
+      Repo.insert!(changeset)
+    end
+
     company
   end
 
@@ -36,7 +43,7 @@ defmodule Gatekeeper.Factory do
 
     if params[:door_group] do
       changeset = DoorGroupMember.changeset(%DoorGroupMember{}, %{member_id: member.id, door_group_id: params.door_group.id})
-      Repo.insert(changeset)
+      Repo.insert!(changeset)
     end
 
     member
@@ -76,7 +83,7 @@ defmodule Gatekeeper.Factory do
 
     if params[:door_group] do
       changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, %{door_id: door.id, door_group_id: params.door_group.id})
-      Repo.insert(changeset)
+      Repo.insert!(changeset)
     end
 
     door

--- a/test/factory.exs
+++ b/test/factory.exs
@@ -8,7 +8,6 @@ defmodule Gatekeeper.Factory do
   alias Gatekeeper.DoorGroup
   alias Gatekeeper.DoorGroupDoor
   alias Gatekeeper.DoorGroupMember
-  alias Gatekeeper.DoorGroupCompany
 
   def create_company(params \\ %{}) do
     default_params = %{

--- a/test/models/door_group_company_test.exs
+++ b/test/models/door_group_company_test.exs
@@ -1,0 +1,18 @@
+defmodule Gatekeeper.DoorGroupCompanyTest do
+  use Gatekeeper.ModelCase
+
+  alias Gatekeeper.DoorGroupCompany
+
+  @valid_attrs %{company_id: 42, door_group_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = DoorGroupCompany.changeset(%DoorGroupCompany{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = DoorGroupCompany.changeset(%DoorGroupCompany{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/door_group_doors_test.exs
+++ b/test/models/door_group_doors_test.exs
@@ -1,18 +1,18 @@
-defmodule Gatekeeper.DoorGroupDoorsTest do
+defmodule Gatekeeper.DoorGroupDoorTest do
   use Gatekeeper.ModelCase
 
-  alias Gatekeeper.DoorGroupDoors
+  alias Gatekeeper.DoorGroupDoor
 
   @valid_attrs %{door_group_id: 42, door_id: 42}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do
-    changeset = DoorGroupDoors.changeset(%DoorGroupDoors{}, @valid_attrs)
+    changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, @valid_attrs)
     assert changeset.valid?
   end
 
   test "changeset with invalid attributes" do
-    changeset = DoorGroupDoors.changeset(%DoorGroupDoors{}, @invalid_attrs)
+    changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, @invalid_attrs)
     refute changeset.valid?
   end
 end

--- a/test/models/door_group_doors_test.exs
+++ b/test/models/door_group_doors_test.exs
@@ -1,0 +1,18 @@
+defmodule Gatekeeper.DoorGroupDoorsTest do
+  use Gatekeeper.ModelCase
+
+  alias Gatekeeper.DoorGroupDoors
+
+  @valid_attrs %{door_group_id: 42, door_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = DoorGroupDoors.changeset(%DoorGroupDoors{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = DoorGroupDoors.changeset(%DoorGroupDoors{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/door_group_member_test.exs
+++ b/test/models/door_group_member_test.exs
@@ -1,0 +1,18 @@
+defmodule Gatekeeper.DoorGroupMemberTest do
+  use Gatekeeper.ModelCase
+
+  alias Gatekeeper.DoorGroupMember
+
+  @valid_attrs %{door_group_id: 42, member_id: 42}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = DoorGroupMember.changeset(%DoorGroupMember{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = DoorGroupMember.changeset(%DoorGroupMember{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/door_group_test.exs
+++ b/test/models/door_group_test.exs
@@ -1,0 +1,18 @@
+defmodule Gatekeeper.DoorGroupTest do
+  use Gatekeeper.ModelCase
+
+  alias Gatekeeper.DoorGroup
+
+  @valid_attrs %{name: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = DoorGroup.changeset(%DoorGroup{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = DoorGroup.changeset(%DoorGroup{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/door_test.exs
+++ b/test/models/door_test.exs
@@ -1,0 +1,18 @@
+defmodule Gatekeeper.DoorTest do
+  use Gatekeeper.ModelCase
+
+  alias Gatekeeper.Door
+
+  @valid_attrs %{name: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Door.changeset(%Door{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Door.changeset(%Door{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/door_test.exs
+++ b/test/models/door_test.exs
@@ -1,6 +1,8 @@
 defmodule Gatekeeper.DoorTest do
   use Gatekeeper.ModelCase
 
+  import Gatekeeper.Factory
+
   alias Gatekeeper.Door
 
   @valid_attrs %{name: "some content"}
@@ -14,5 +16,32 @@ defmodule Gatekeeper.DoorTest do
   test "changeset with invalid attributes" do
     changeset = Door.changeset(%Door{}, @invalid_attrs)
     refute changeset.valid?
+  end
+
+  test "member is disallowed access if he does not have any association with a door group containing the door" do
+    door_group = create_door_group
+    door = create_door door_group: door_group
+    company = create_company
+    member = create_member company: company
+
+    refute Door.member_access_allowed? door, member
+  end
+
+  test "member is allowed access if he has an association with a door group containing the door" do
+    door_group = create_door_group
+    door = create_door door_group: door_group
+    company = create_company
+    member = create_member company: company, door_group: door_group
+
+    assert Door.member_access_allowed? door, member
+  end
+
+  test "member is allowed access if his company has an association with a door group containing the door" do
+    door_group = create_door_group
+    door = create_door door_group: door_group
+    company = create_company door_group: door_group
+    member = create_member company: company
+
+    assert Door.member_access_allowed? door, member
   end
 end

--- a/test/models/rfid_token_test.exs
+++ b/test/models/rfid_token_test.exs
@@ -38,7 +38,7 @@ defmodule Gatekeeper.RfidTokenTest do
     {:ok, member} = Repo.insert(changeset)
 
     if params[:door_group] do
-      changeset = DoorGroupMember.changeset(%DoorGroupMember{}, member_id: member.id, door_group_id: params.door_group.id)
+      changeset = DoorGroupMember.changeset(%DoorGroupMember{}, %{member_id: member.id, door_group_id: params.door_group.id})
       Repo.insert(changeset)
     end
 
@@ -78,7 +78,7 @@ defmodule Gatekeeper.RfidTokenTest do
     {:ok, door} = Repo.insert(changeset)
 
     if params[:door_group] do
-      changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, door_id: door.id, door_group_id: params.door_group.id)
+      changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, %{door_id: door.id, door_group_id: params.door_group.id})
       Repo.insert(changeset)
     end
 
@@ -121,32 +121,40 @@ defmodule Gatekeeper.RfidTokenTest do
     door = create_door door_group: door_group
     member = create_member company: company, door_group: door_group
     rfid_token = create_rfid_token member: member
-    assert RfidToken.access_permitted?("abcd1234", door.id)
+    assert RfidToken.access_permitted?(rfid_token.identifier, door.id)
   end
 
   test "checking that the door should not be allowed to open if the token is inactive" do
     company = create_company
     member = create_member company: company
+    door_group = create_door_group
+    door = create_door door_group: door_group
     rfid_token = create_rfid_token member: member, active: false
-    refute RfidToken.access_permitted?("abcd1234")
+    refute RfidToken.access_permitted?(rfid_token.identifier, door.id)
   end
 
   test "the door should not be allowed to open if the member is inactive" do
     company = create_company
     member = create_member company: company, active: false
+    door_group = create_door_group
+    door = create_door door_group: door_group
     rfid_token = create_rfid_token member: member
-    refute RfidToken.access_permitted?("abcd1234")
+    refute RfidToken.access_permitted?(rfid_token.identifier, door.id)
   end
 
   test "the door should not be allowed to open if the company departed" do
     {:ok, departure} = Ecto.DateTime.cast("2015-04-30 00:00:00")
     company = create_company departure_date: departure
     member = create_member company: company
+    door_group = create_door_group
+    door = create_door door_group: door_group
     rfid_token = create_rfid_token member: member
-    refute RfidToken.access_permitted?("abcd1234")
+    refute RfidToken.access_permitted?(rfid_token.identifier, door.id)
   end
 
   test "the door should not be allowed to open if the token is not enrolled" do
-    refute RfidToken.access_permitted?("abcd1234")
+    door_group = create_door_group
+    door = create_door door_group: door_group
+    refute RfidToken.access_permitted?("does_not_exist", door.id)
   end
 end

--- a/test/models/rfid_token_test.exs
+++ b/test/models/rfid_token_test.exs
@@ -1,89 +1,11 @@
 defmodule Gatekeeper.RfidTokenTest do
   use Gatekeeper.ModelCase
+  import Gatekeeper.Factory
 
   alias Gatekeeper.RfidToken
-  alias Gatekeeper.Member
-  alias Gatekeeper.Company
-  alias Gatekeeper.Door
-  alias Gatekeeper.DoorGroup
-  alias Gatekeeper.DoorGroupDoor
-  alias Gatekeeper.DoorGroupMember
 
   @valid_attrs %{identifier: "some content", active: false, member_id: 1}
   @invalid_attrs %{}
-
-  def create_company(params \\ %{}) do
-    default_params = %{
-      name: "Test Company",
-      join_date: :calendar.local_time(),
-      departure_date: nil,
-    }
-    params = Dict.merge(default_params, params)
-    changeset = Company.changeset(%Company{}, params)
-    {:ok, company} = Repo.insert(changeset)
-    company
-  end
-
-  def create_member(params \\ %{}) do
-    default_params = %{
-      name: "Test Member",
-      email: "test@example.com",
-      active: true,
-    }
-    # :company is a required parameter
-    default_params = Dict.merge(default_params, company_id: params[:company].id)
-
-    params = Dict.merge(default_params, params)
-    changeset = Member.changeset(%Member{}, params)
-    {:ok, member} = Repo.insert(changeset)
-
-    if params[:door_group] do
-      changeset = DoorGroupMember.changeset(%DoorGroupMember{}, %{member_id: member.id, door_group_id: params.door_group.id})
-      Repo.insert(changeset)
-    end
-
-    member
-  end
-
-  def create_rfid_token(params \\ %{}) do
-    default_params = %{
-      identifier: "abcd1234",
-      active: true,
-    }
-    # :member is a required parameter
-    default_params = Dict.merge(default_params, member_id: params[:member].id)
-
-    params = Dict.merge(default_params, params)
-    changeset = RfidToken.changeset(%RfidToken{}, params)
-    {:ok, rfid_token} = Repo.insert(changeset)
-    rfid_token
-  end
-
-  def create_door_group(params \\ %{}) do
-    default_params = %{
-      name: "Test Dooor Group",
-    }
-    params = Dict.merge(default_params, params)
-    changeset = DoorGroup.changeset(%DoorGroup{}, params)
-    {:ok, door_group} = Repo.insert(changeset)
-    door_group
-  end
-
-  def create_door(params \\ %{}) do
-    default_params = %{
-      name: "Test Door",
-    }
-    params = Dict.merge(default_params, params)
-    changeset = Door.changeset(%Door{}, params)
-    {:ok, door} = Repo.insert(changeset)
-
-    if params[:door_group] do
-      changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, %{door_id: door.id, door_group_id: params.door_group.id})
-      Repo.insert(changeset)
-    end
-
-    door
-  end
 
   test "changeset with valid attributes" do
     changeset = RfidToken.changeset(%RfidToken{}, @valid_attrs)

--- a/test/models/rfid_token_test.exs
+++ b/test/models/rfid_token_test.exs
@@ -8,6 +8,47 @@ defmodule Gatekeeper.RfidTokenTest do
   @valid_attrs %{identifier: "some content", active: false, member_id: 1}
   @invalid_attrs %{}
 
+  def create_company(params \\ %{}) do
+    default_params = %{
+      name: "Test Company",
+      join_date: :calendar.local_time(),
+      departure_date: nil
+    }
+    params = Dict.merge(default_params, params)
+    changeset = Company.changeset(%Company{}, params)
+    {:ok, company} = Repo.insert(changeset)
+    company
+  end
+
+  def create_member(params \\ %{}) do
+    default_params = %{
+      name: "Test Member",
+      email: "test@example.com",
+      active: true
+    }
+    # :company is a required parameter
+    default_params = Dict.merge(default_params, company_id: params[:company].id)
+
+    params = Dict.merge(default_params, params)
+    changeset = Member.changeset(%Member{}, params)
+    {:ok, member} = Repo.insert(changeset)
+    member
+  end
+
+  def create_rfid_token(params \\ %{}) do
+    default_params = %{
+      identifier: "abcd1234",
+      active: true,
+    }
+    # :member is a required parameter
+    default_params = Dict.merge(default_params, member_id: params[:member].id)
+
+    params = Dict.merge(default_params, params)
+    changeset = RfidToken.changeset(%RfidToken{}, params)
+    {:ok, rfid_token} = Repo.insert(changeset)
+    rfid_token
+  end
+
   test "changeset with valid attributes" do
     changeset = RfidToken.changeset(%RfidToken{}, @valid_attrs)
     assert changeset.valid?
@@ -19,51 +60,51 @@ defmodule Gatekeeper.RfidTokenTest do
   end
 
   test "checks whether an RFID token permits access when it should" do
-    m = %RfidToken{active: true, member: %Member{active: true, company: %Company{departure_date: nil}}}
+    m = %RfidToken{active: true, member: create_member(company: create_company)}
     assert RfidToken.active?(m)
   end
 
   test "checking for an inactive RFID token" do
-    m = %RfidToken{active: false, member: %Member{active: true, company: %Company{departure_date: nil}}}
+    m = %RfidToken{active: false, member: create_member(company: create_company)}
     refute RfidToken.active?(m)
   end
 
   test "checking for an inactive member" do
-    m = %RfidToken{active: true, member: %Member{active: false, company: %Company{departure_date: nil}}}
+    m = %RfidToken{active: true, member: create_member(active: false, company: create_company)}
     refute RfidToken.active?(m)
   end
 
   test "checking for an inactive company" do
-    m = %RfidToken{active: true, member: %Member{active: true, company: %Company{departure_date: "2015-04-30 00:00:00"}}}
+    m = %RfidToken{active: true, member: create_member(company: create_company(departure_date: "2015-04-30 00:00:00"))}
     refute RfidToken.active?(m)
   end
 
   test "checking that the door should be allowed to open" do
-    {:ok, company} = Gatekeeper.Repo.insert %Company{departure_date: nil}
-    {:ok, member} = Gatekeeper.Repo.insert %Member{active: true, company_id: company.id}
-    Gatekeeper.Repo.insert %RfidToken{identifier: "abcd1234", active: true, member_id: member.id}
+    company = create_company
+    member = create_member company: company
+    rfid_token = create_rfid_token member: member
     assert RfidToken.access_permitted?("abcd1234")
   end
 
   test "checking that the door should not be allowed to open if the token is inactive" do
-    {:ok, company} = Gatekeeper.Repo.insert %Company{departure_date: nil}
-    {:ok, member} = Gatekeeper.Repo.insert %Member{active: true, company_id: company.id}
-    Gatekeeper.Repo.insert %RfidToken{identifier: "abcd1234", active: false, member_id: member.id}
+    company = create_company
+    member = create_member company: company
+    rfid_token = create_rfid_token member: member, active: false
     refute RfidToken.access_permitted?("abcd1234")
   end
 
   test "the door should not be allowed to open if the member is inactive" do
-    {:ok, company} = Gatekeeper.Repo.insert %Company{departure_date: nil}
-    {:ok, member} = Gatekeeper.Repo.insert %Member{active: false, company_id: company.id}
-    Gatekeeper.Repo.insert %RfidToken{identifier: "abcd1234", active: true, member_id: member.id}
+    company = create_company
+    member = create_member company: company, active: false
+    rfid_token = create_rfid_token member: member
     refute RfidToken.access_permitted?("abcd1234")
   end
 
   test "the door should not be allowed to open if the company departed" do
     {:ok, departure} = Ecto.DateTime.cast("2015-04-30 00:00:00")
-    {:ok, company} = Gatekeeper.Repo.insert %Company{departure_date: departure}
-    {:ok, member} = Gatekeeper.Repo.insert %Member{active: true, company_id: company.id}
-    Gatekeeper.Repo.insert %RfidToken{identifier: "abcd1234", active: true, member_id: member.id}
+    company = create_company departure_date: departure
+    member = create_member company: company
+    rfid_token = create_rfid_token member: member
     refute RfidToken.access_permitted?("abcd1234")
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,3 +5,5 @@ Mix.Task.run "ecto.migrate", ["--quiet"]
 Ecto.Adapters.SQL.begin_test_transaction(Gatekeeper.Repo)
 
 ExUnit.configure(exclude: [skip: true])
+
+Code.load_file "test/factory.exs"

--- a/web/controllers/company_controller.ex
+++ b/web/controllers/company_controller.ex
@@ -2,8 +2,14 @@ defmodule Gatekeeper.CompanyController do
   use Gatekeeper.Web, :controller
 
   alias Gatekeeper.Company
+  alias Gatekeeper.DoorGroup
+  alias Gatekeeper.DoorGroupCompany
 
   plug :scrub_params, "company" when action in [:create, :update]
+
+  def blank_company do
+    %Company{} |> Repo.preload([:members, :door_groups])
+  end
 
   def index(conn, _params) do
     companies = Repo.all(Company) |> Repo.preload(:members)
@@ -11,45 +17,52 @@ defmodule Gatekeeper.CompanyController do
   end
 
   def new(conn, _params) do
-    changeset = Company.changeset %Company{ members: [ %Gatekeeper.Member{} ] }
-    render(conn, "new.html", changeset: changeset)
+    company = blank_company
+    changeset = Company.changeset(company)
+    door_groups = Repo.all(DoorGroup)
+    render(conn, "new.html", company: company, changeset: changeset, door_groups: door_groups)
   end
 
   def create(conn, %{"company" => company_params}) do
+    door_groups = Repo.all(DoorGroup)
     changeset = Company.changeset(%Company{}, company_params)
 
     case Repo.insert(changeset) do
-      {:ok, _company} ->
+      {:ok, company} ->
+        save_door_groups(company, company_params["door_groups"])
         conn
         |> put_flash(:info, "Company created successfully.")
         |> redirect(to: company_path(conn, :index))
       {:error, changeset} ->
-        render(conn, "new.html", changeset: changeset)
+        render(conn, "new.html", company: blank_company, changeset: changeset, door_groups: door_groups)
     end
   end
 
   def show(conn, %{"id" => id}) do
-    company = Repo.get!(Company, id) |> Repo.preload(:members)
+    company = Repo.get!(Company, id) |> Repo.preload([:members, :door_groups])
     render(conn, "show.html", company: company)
   end
 
   def edit(conn, %{"id" => id}) do
-    company = Repo.get!(Company, id) |> Repo.preload(:members)
+    company = Repo.get!(Company, id) |> Repo.preload([:members, :door_groups])
     changeset = Company.changeset(company)
-    render(conn, "edit.html", company: company, changeset: changeset)
+    door_groups = Repo.all(DoorGroup)
+    render(conn, "edit.html", company: company, changeset: changeset, door_groups: door_groups)
   end
 
   def update(conn, %{"id" => id, "company" => company_params}) do
-    company = Repo.get!(Company, id) |> Repo.preload :members
+    company = Repo.get!(Company, id) |> Repo.preload([:members, :door_groups])
+    door_groups = Repo.all(DoorGroup)
     changeset = Company.changeset(company, company_params)
 
     case Repo.update(changeset) do
       {:ok, company} ->
+        save_door_groups(company, company_params["door_groups"])
         conn
         |> put_flash(:info, "Company updated successfully.")
         |> redirect(to: company_path(conn, :show, company))
       {:error, changeset} ->
-        render(conn, "edit.html", company: company, changeset: changeset)
+        render(conn, "edit.html", company: company, changeset: changeset, door_groups: door_groups)
     end
   end
 
@@ -63,5 +76,18 @@ defmodule Gatekeeper.CompanyController do
     conn
     |> put_flash(:info, "Company deleted successfully.")
     |> redirect(to: company_path(conn, :index))
+  end
+
+  def save_door_groups(company, new_door_group_ids) do
+    # Remove all existing door <-> door group associations
+    Ecto.Query.from(door_group_company in DoorGroupCompany, where: door_group_company.company_id == ^company.id) |> Repo.delete_all
+
+    # Insert new door <-> door group associations based on provided checkboxes
+    if new_door_group_ids do # can be nil if no boxes were checked
+      for {id, _val} <- new_door_group_ids do
+        changeset = DoorGroupCompany.changeset(%DoorGroupCompany{}, %{company_id: company.id, door_group_id: id})
+        {:ok, _} = Repo.insert(changeset)
+      end
+    end
   end
 end

--- a/web/controllers/door_controller.ex
+++ b/web/controllers/door_controller.ex
@@ -1,0 +1,67 @@
+defmodule Gatekeeper.DoorController do
+  use Gatekeeper.Web, :controller
+
+  alias Gatekeeper.Door
+
+  plug :scrub_params, "door" when action in [:create, :update]
+
+  def index(conn, _params) do
+    doors = Repo.all(Door)
+    render(conn, "index.html", doors: doors)
+  end
+
+  def new(conn, _params) do
+    changeset = Door.changeset(%Door{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"door" => door_params}) do
+    changeset = Door.changeset(%Door{}, door_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _door} ->
+        conn
+        |> put_flash(:info, "Door created successfully.")
+        |> redirect(to: door_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    door = Repo.get!(Door, id)
+    render(conn, "show.html", door: door)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    door = Repo.get!(Door, id)
+    changeset = Door.changeset(door)
+    render(conn, "edit.html", door: door, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "door" => door_params}) do
+    door = Repo.get!(Door, id)
+    changeset = Door.changeset(door, door_params)
+
+    case Repo.update(changeset) do
+      {:ok, door} ->
+        conn
+        |> put_flash(:info, "Door updated successfully.")
+        |> redirect(to: door_path(conn, :show, door))
+      {:error, changeset} ->
+        render(conn, "edit.html", door: door, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    door = Repo.get!(Door, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(door)
+
+    conn
+    |> put_flash(:info, "Door deleted successfully.")
+    |> redirect(to: door_path(conn, :index))
+  end
+end

--- a/web/controllers/door_group_controller.ex
+++ b/web/controllers/door_group_controller.ex
@@ -39,7 +39,7 @@ defmodule Gatekeeper.DoorGroupController do
   end
 
   def show(conn, %{"id" => id}) do
-    door_group = Repo.get!(DoorGroup, id) |> Repo.preload :doors
+    door_group = Repo.get!(DoorGroup, id) |> Repo.preload [:doors, :companies]
     render(conn, "show.html", door_group: door_group)
   end
 

--- a/web/controllers/door_group_controller.ex
+++ b/web/controllers/door_group_controller.ex
@@ -39,7 +39,7 @@ defmodule Gatekeeper.DoorGroupController do
   end
 
   def show(conn, %{"id" => id}) do
-    door_group = Repo.get!(DoorGroup, id)
+    door_group = Repo.get!(DoorGroup, id) |> Repo.preload :doors
     render(conn, "show.html", door_group: door_group)
   end
 

--- a/web/controllers/door_group_controller.ex
+++ b/web/controllers/door_group_controller.ex
@@ -16,7 +16,6 @@ defmodule Gatekeeper.DoorGroupController do
   def new(conn, _params) do
     changeset = DoorGroup.changeset(%DoorGroup{})
     doors = Repo.all(Door)
-    IO.puts inspect doors
     render(conn, "new.html", doors: doors, changeset: changeset, foo: "bar")
   end
 

--- a/web/controllers/door_group_controller.ex
+++ b/web/controllers/door_group_controller.ex
@@ -1,0 +1,84 @@
+defmodule Gatekeeper.DoorGroupController do
+  use Gatekeeper.Web, :controller
+  import Ecto.Query
+
+  alias Gatekeeper.DoorGroup
+  alias Gatekeeper.Door
+  alias Gatekeeper.DoorGroupDoor
+
+  plug :scrub_params, "door_group" when action in [:create, :update]
+
+  def index(conn, _params) do
+    door_groups = Repo.all(DoorGroup)
+    render(conn, "index.html", door_groups: door_groups)
+  end
+
+  def new(conn, _params) do
+    changeset = DoorGroup.changeset(%DoorGroup{})
+    doors = Repo.all(Door)
+    IO.puts inspect doors
+    render(conn, "new.html", doors: doors, changeset: changeset, foo: "bar")
+  end
+
+  def create(conn, %{"door_group" => door_group_params}) do
+    changeset = DoorGroup.changeset(%DoorGroup{}, door_group_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _door_group} ->
+        conn
+        |> put_flash(:info, "Door group created successfully.")
+        |> redirect(to: door_group_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    door_group = Repo.get!(DoorGroup, id)
+    render(conn, "show.html", door_group: door_group)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    door_group = Repo.get!(DoorGroup, id) |> Repo.preload :doors
+    doors = Repo.all(Door)
+    changeset = DoorGroup.changeset(door_group)
+    render(conn, "edit.html", door_group: door_group, doors: doors, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "door_group" => door_group_params}) do
+    door_group = Repo.get!(DoorGroup, id)
+    changeset = DoorGroup.changeset(door_group, door_group_params)
+
+    case Repo.update(changeset) do
+      {:ok, door_group} ->
+        # Remove all existing door <-> door group associations
+        Ecto.Query.from(door_group_door in DoorGroupDoor, where: door_group_door.door_group_id == ^door_group.id) |> Repo.delete_all
+
+        # Insert new door <-> door group associations based on provided checkboxes
+        if door_group_params["doors"] do
+          for {id, _door_params} <- door_group_params["doors"] do
+            changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, %{door_group_id: door_group.id, door_id: id})
+            {:ok, _} = Repo.insert(changeset)
+          end
+        end
+
+        conn
+        |> put_flash(:info, "Door group updated successfully.")
+        |> redirect(to: door_group_path(conn, :show, door_group))
+      {:error, changeset} ->
+        render(conn, "edit.html", door_group: door_group, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    door_group = Repo.get!(DoorGroup, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(door_group)
+
+    conn
+    |> put_flash(:info, "Door group deleted successfully.")
+    |> redirect(to: door_group_path(conn, :index))
+  end
+end

--- a/web/controllers/door_group_controller.ex
+++ b/web/controllers/door_group_controller.ex
@@ -20,7 +20,7 @@ defmodule Gatekeeper.DoorGroupController do
   def new(conn, _params) do
     changeset = DoorGroup.changeset(blank_door_group)
     doors = Repo.all(Door)
-    render(conn, "new.html", doors: doors, door_group: blank_door_group, changeset: changeset, foo: "bar")
+    render(conn, "new.html", doors: doors, door_group: blank_door_group, changeset: changeset)
   end
 
   def create(conn, %{"door_group" => door_group_params}) do

--- a/web/models/company.ex
+++ b/web/models/company.ex
@@ -6,6 +6,8 @@ defmodule Gatekeeper.Company do
     field :join_date, Ecto.DateTime
     field :departure_date, Ecto.DateTime
     has_many :members, Gatekeeper.Member, on_delete: :fetch_and_delete
+    has_many :door_group_companies, Gatekeeper.DoorGroupCompany, on_delete: :fetch_and_delete
+    has_many :door_groups, through: [:door_group_companies, :company]
 
     timestamps
   end

--- a/web/models/company.ex
+++ b/web/models/company.ex
@@ -7,7 +7,7 @@ defmodule Gatekeeper.Company do
     field :departure_date, Ecto.DateTime
     has_many :members, Gatekeeper.Member, on_delete: :fetch_and_delete
     has_many :door_group_companies, Gatekeeper.DoorGroupCompany, on_delete: :fetch_and_delete
-    has_many :door_groups, through: [:door_group_companies, :company]
+    has_many :door_groups, through: [:door_group_companies, :door_group]
 
     timestamps
   end

--- a/web/models/door.ex
+++ b/web/models/door.ex
@@ -1,0 +1,36 @@
+defmodule Gatekeeper.Door do
+  use Gatekeeper.Web, :model
+
+  alias Gatekeeper.Repo
+
+  schema "doors" do
+    field :name, :string
+    has_many :door_group_doors, Gatekeeper.DoorGroupDoor
+    has_many :door_groups, through: [:door_group_doors, :door_group]
+
+    timestamps
+  end
+
+  @required_fields ~w(name)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+
+  def member_access_allowed?(door, member) do
+    member.id in Enum.map(members(door), &(&1.id))
+  end
+
+  def members(door) do
+    door = Repo.preload(door, [door_groups: :members])
+    Enum.reduce([ [] | door.door_groups ], &(&2 ++ &1.members))
+  end
+end

--- a/web/models/door.ex
+++ b/web/models/door.ex
@@ -30,7 +30,10 @@ defmodule Gatekeeper.Door do
   end
 
   def members(door) do
-    door = Repo.preload(door, [door_groups: :members])
-    Enum.reduce([ [] | door.door_groups ], &(&2 ++ &1.members))
+    door = Repo.preload(door, [door_groups: [:members, companies: :members]])
+    members = Enum.reduce([ [] | door.door_groups ], &(&2 ++ &1.members))
+    companies = Enum.reduce([ [] | door.door_groups ], &(&2 ++ &1.companies))
+    company_members = Enum.reduce([ [] | companies ], &(&2 ++ &1.members))
+    members ++ company_members
   end
 end

--- a/web/models/door_group.ex
+++ b/web/models/door_group.ex
@@ -6,6 +6,9 @@ defmodule Gatekeeper.DoorGroup do
     has_many :door_group_doors, Gatekeeper.DoorGroupDoor
     has_many :doors, through: [:door_group_doors, :door]
 
+    has_many :door_group_companies, Gatekeeper.DoorGroupCompany
+    has_many :companies, through: [:door_group_companies, :company]
+
     has_many :door_group_members, Gatekeeper.DoorGroupMember
     has_many :members, through: [:door_group_members, :member]
 

--- a/web/models/door_group.ex
+++ b/web/models/door_group.ex
@@ -1,0 +1,28 @@
+defmodule Gatekeeper.DoorGroup do
+  use Gatekeeper.Web, :model
+
+  schema "door_groups" do
+    field :name, :string
+    has_many :door_group_doors, Gatekeeper.DoorGroupDoor
+    has_many :doors, through: [:door_group_doors, :door]
+
+    has_many :door_group_members, Gatekeeper.DoorGroupMember
+    has_many :members, through: [:door_group_members, :member]
+
+    timestamps
+  end
+
+  @required_fields ~w(name)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/web/models/door_group_company.ex
+++ b/web/models/door_group_company.ex
@@ -1,0 +1,24 @@
+defmodule Gatekeeper.DoorGroupCompany do
+  use Gatekeeper.Web, :model
+
+  schema "door_group_companies" do
+    belongs_to :door_group, Gatekeeper.DoorGroup
+    belongs_to :company, Gatekeeper.Company
+
+    timestamps
+  end
+
+  @required_fields ~w(door_group_id company_id)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/web/models/door_group_door.ex
+++ b/web/models/door_group_door.ex
@@ -1,0 +1,24 @@
+defmodule Gatekeeper.DoorGroupDoor do
+  use Gatekeeper.Web, :model
+
+  schema "door_group_doors" do
+    belongs_to :door_group, Gatekeeper.DoorGroup
+    belongs_to :door, Gatekeeper.Door
+
+    timestamps
+  end
+
+  @required_fields ~w(door_group_id door_id)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/web/models/door_group_member.ex
+++ b/web/models/door_group_member.ex
@@ -1,0 +1,24 @@
+defmodule Gatekeeper.DoorGroupMember do
+  use Gatekeeper.Web, :model
+
+  schema "door_group_members" do
+    belongs_to :door_group, Gatekeeper.DoorGroup
+    belongs_to :member, Gatekeeper.Member
+
+    timestamps
+  end
+
+  @required_fields ~w(door_group_id member_id)
+  @optional_fields ~w()
+
+  @doc """
+  Creates a changeset based on the `model` and `params`.
+
+  If no params are provided, an invalid changeset is returned
+  with no validation performed.
+  """
+  def changeset(model, params \\ :empty) do
+    model
+    |> cast(params, @required_fields, @optional_fields)
+  end
+end

--- a/web/models/member.ex
+++ b/web/models/member.ex
@@ -13,6 +13,10 @@ defmodule Gatekeeper.Member do
     belongs_to :company, Company
     has_many :rfid_tokens, RfidToken
 
+    has_many :door_group_members, Gatekeeper.DoorGroupMember
+    has_many :door_groups, through: [:door_group_members, :door_group]
+    has_many :doors, through: [:door_groups, :door]
+
     timestamps
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -22,6 +22,9 @@ defmodule Gatekeeper.Router do
         resources "/rfid_tokens", RfidTokenController
       end
     end
+
+    resources "/doors", DoorController
+    resources "/door_groups", DoorGroupController
   end
 
   # Other scopes may use custom stacks.

--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -84,3 +84,7 @@ form.link, form.button {
 ul.member-list {
   margin: 0;
 }
+
+p.no-associations {
+  font-style: italic;
+}

--- a/web/templates/company/edit.html.eex
+++ b/web/templates/company/edit.html.eex
@@ -1,6 +1,5 @@
 <h2>Edit company</h2>
 
-<%= render "form.html", changeset: @changeset,
-                        action: company_path(@conn, :update, @company) %>
+<%= render "form.html", Dict.merge(@conn.assigns, action: company_path(@conn, :update, @company)) %>
 
 <%= link "Back", to: company_path(@conn, :index) %>

--- a/web/templates/company/form.html.eex
+++ b/web/templates/company/form.html.eex
@@ -24,7 +24,6 @@
     <h4>Doors Groups</h4>
     <p>Check each door group to which this company should have access</p>
     <table class="table">
-      <% IO.puts inspect @company %>
       <% door_group_ids = Enum.map @company.door_groups, &(&1.id) %>
       <%= for door_group <- @door_groups do %>
         <tr>

--- a/web/templates/company/form.html.eex
+++ b/web/templates/company/form.html.eex
@@ -21,7 +21,7 @@
   </div>
 
   <div class="form-group">
-    <h4>Doors Groups</h4>
+    <h4>Door Groups</h4>
     <p>Check each door group to which this company should have access</p>
     <table class="table">
       <% door_group_ids = Enum.map @company.door_groups, &(&1.id) %>

--- a/web/templates/company/form.html.eex
+++ b/web/templates/company/form.html.eex
@@ -21,6 +21,21 @@
   </div>
 
   <div class="form-group">
+    <h4>Doors Groups</h4>
+    <p>Check each door group to which this company should have access</p>
+    <table class="table">
+      <% IO.puts inspect @company %>
+      <% door_group_ids = Enum.map @company.door_groups, &(&1.id) %>
+      <%= for door_group <- @door_groups do %>
+        <tr>
+          <td><input name="company[door_groups][<%= door_group.id %>]" type="checkbox" <%= (door_group.id in door_group_ids) && "checked" %>></td>
+          <td><%= door_group.name %></td>
+        </tr>
+      <%= end %>
+    </table>
+  </div>
+
+  <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/company/new.html.eex
+++ b/web/templates/company/new.html.eex
@@ -1,6 +1,5 @@
 <h2>New company</h2>
 
-<%= render "form.html", changeset: @changeset,
-                        action: company_path(@conn, :create) %>
+<%= render "form.html", Dict.merge(@conn.assigns, action: company_path(@conn, :create)) %>
 
 <%= link "Back", to: company_path(@conn, :index) %>

--- a/web/templates/company/show.html.eex
+++ b/web/templates/company/show.html.eex
@@ -13,16 +13,26 @@
   </li>
 
   <li>
-    <strong>Members:</strong>
-    <ul class="member-list">
-      <%= for member <- @company.members do %>
-        <li><%= link member.name, to: company_member_path(@conn, :show, @company, member) %></li>
-      <% end %>
-      <li><%= link "Add new...", to: company_member_path(@conn, :new, @company) %></li>
-    </ul>
+    <strong>Access to Door Groups:</strong>
+    <%= if length(@company.door_groups) > 0 do %>
+      <ul class="door-group-list">
+        <%= for door_group <- @company.door_groups do %>
+          <li><%= link door_group.name, to: door_group_path(@conn, :show, door_group) %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="no-associations">No Door Group Access</p>
+    <% end %>
   </li>
+</ul>
+<%= link "Edit", to: company_path(@conn, :edit, @company) %> |
+<%= link "Back", to: company_path(@conn, :index) %>
 
+<h4>Members:</h4>
+<ul class="member-list">
+  <%= for member <- @company.members do %>
+    <li><%= link member.name, to: company_member_path(@conn, :show, @company, member) %></li>
+  <% end %>
+  <li><%= link "Add new...", to: company_member_path(@conn, :new, @company) %></li>
 </ul>
 
-<%= link "Edit", to: company_path(@conn, :edit, @company) %>
-<%= link "Back", to: company_path(@conn, :index) %>

--- a/web/templates/door/edit.html.eex
+++ b/web/templates/door/edit.html.eex
@@ -1,0 +1,6 @@
+<h2>Edit door</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: door_path(@conn, :update, @door) %>
+
+<%= link "Back", to: door_path(@conn, :index) %>

--- a/web/templates/door/form.html.eex
+++ b/web/templates/door/form.html.eex
@@ -1,0 +1,21 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below:</p>
+      <ul>
+        <%= for {attr, message} <- f.errors do %>
+          <li><%= humanize(attr) %> <%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :name, "Name", class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/door/index.html.eex
+++ b/web/templates/door/index.html.eex
@@ -1,0 +1,26 @@
+<h2>Listing doors</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for door <- @doors do %>
+    <tr>
+      <td><%= door.name %></td>
+
+      <td class="text-right">
+        <%= link "Show", to: door_path(@conn, :show, door), class: "btn btn-default btn-xs" %>
+        <%= link "Edit", to: door_path(@conn, :edit, door), class: "btn btn-default btn-xs" %>
+        <%= link "Delete", to: door_path(@conn, :delete, door), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<%= link "New door", to: door_path(@conn, :new) %>

--- a/web/templates/door/new.html.eex
+++ b/web/templates/door/new.html.eex
@@ -1,0 +1,6 @@
+<h2>New door</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: door_path(@conn, :create) %>
+
+<%= link "Back", to: door_path(@conn, :index) %>

--- a/web/templates/door/show.html.eex
+++ b/web/templates/door/show.html.eex
@@ -1,0 +1,13 @@
+<h2>Show door</h2>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @door.name %>
+  </li>
+
+</ul>
+
+<%= link "Edit", to: door_path(@conn, :edit, @door) %>
+<%= link "Back", to: door_path(@conn, :index) %>

--- a/web/templates/door_group/edit.html.eex
+++ b/web/templates/door_group/edit.html.eex
@@ -1,0 +1,5 @@
+<h2>Edit door group</h2>
+
+<%= render "form.html", Dict.merge(@conn.assigns, action: door_group_path(@conn, :update, @door_group)) %>
+
+<%= link "Back", to: door_group_path(@conn, :index) %>

--- a/web/templates/door_group/form.html.eex
+++ b/web/templates/door_group/form.html.eex
@@ -1,0 +1,34 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below:</p>
+      <ul>
+        <%= for {attr, message} <- f.errors do %>
+          <li><%= humanize(attr) %> <%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :name, "Name", class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <h4>Doors in this Group</h4>
+    <table class="table">
+      <%= door_ids = Enum.map @door_group.doors, &(&1.id) %>
+      <%= for door <- @doors do %>
+        <tr>
+          <td><input name="door_group[doors][<%= door.id %>]" type="checkbox" <%= (door.id in door_ids) && "checked" %>></td>
+          <td><%= door.name %></td>
+        </tr>
+      <%= end %>
+    </table>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/door_group/index.html.eex
+++ b/web/templates/door_group/index.html.eex
@@ -1,0 +1,26 @@
+<h2>Listing door groups</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for door_group <- @door_groups do %>
+    <tr>
+      <td><%= door_group.name %></td>
+
+      <td class="text-right">
+        <%= link "Show", to: door_group_path(@conn, :show, door_group), class: "btn btn-default btn-xs" %>
+        <%= link "Edit", to: door_group_path(@conn, :edit, door_group), class: "btn btn-default btn-xs" %>
+        <%= link "Delete", to: door_group_path(@conn, :delete, door_group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<%= link "New door group", to: door_group_path(@conn, :new) %>

--- a/web/templates/door_group/new.html.eex
+++ b/web/templates/door_group/new.html.eex
@@ -1,0 +1,5 @@
+<h2>New door group</h2>
+
+<%= render "form.html", Dict.merge(@conn.assigns, action: door_group_path(@conn, :create)) %>
+
+<%= link "Back", to: door_group_path(@conn, :index) %>

--- a/web/templates/door_group/show.html.eex
+++ b/web/templates/door_group/show.html.eex
@@ -7,5 +7,17 @@
   <% end %>
 </ul>
 
+<h4>Companies with access to this group</h4>
+<%= if length(@door_group.companies) > 0 do %>
+  <ul>
+    <%= for company <- @door_group.companies do %>
+      <li><%= link company.name, to: company_path(@conn, :show, company) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p class="no-associations">No companies</p>
+<% end %>
+
+
 <%= link "Edit", to: door_group_path(@conn, :edit, @door_group) %>
 <%= link "Back", to: door_group_path(@conn, :index) %>

--- a/web/templates/door_group/show.html.eex
+++ b/web/templates/door_group/show.html.eex
@@ -1,12 +1,10 @@
-<h2>Show door group</h2>
+<h2>Door Group: <%= @door_group.name %></h2>
 
+<h4>Associated Doors</h4>
 <ul>
-
-  <li>
-    <strong>Name:</strong>
-    <%= @door_group.name %>
-  </li>
-
+  <%= for door <- @door_group.doors do %>
+    <li><%= link door.name, to: door_path(@conn, :show, door) %></li>
+  <% end %>
 </ul>
 
 <%= link "Edit", to: door_group_path(@conn, :edit, @door_group) %>

--- a/web/templates/door_group/show.html.eex
+++ b/web/templates/door_group/show.html.eex
@@ -1,0 +1,13 @@
+<h2>Show door group</h2>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @door_group.name %>
+  </li>
+
+</ul>
+
+<%= link "Edit", to: door_group_path(@conn, :edit, @door_group) %>
+<%= link "Back", to: door_group_path(@conn, :index) %>

--- a/web/templates/member/edit.html.eex
+++ b/web/templates/member/edit.html.eex
@@ -1,6 +1,5 @@
 <h2>Edit member</h2>
 
-<%= render "form.html", changeset: @changeset,
-                        action: company_member_path(@conn, :update, @company, @member) %>
+<%= render "form.html", Dict.merge(@conn.assigns, action: company_member_path(@conn, :update, @company, @member), conn: @conn) %>
 
 <%= link "Back", to: company_path(@conn, :index) %>

--- a/web/templates/member/form.html.eex
+++ b/web/templates/member/form.html.eex
@@ -31,6 +31,22 @@
   </div>
 
   <div class="form-group">
+    <h4>Door Groups</h4>
+    <p>Check each door group to which this member should have access</p>
+    <p>Note! use this only if this member needs special access. Most members will have access through his/her <%= link "company", to: company_path(@conn, :show, @company) %>.
+    <table class="table">
+      <% door_group_ids = Enum.map @member.door_groups, &(&1.id) %>
+      <%= for door_group <- @door_groups do %>
+        <tr>
+          <td><input name="member[door_groups][<%= door_group.id %>]" type="checkbox" <%= (door_group.id in door_group_ids) && "checked" %>></td>
+          <td><%= door_group.name %></td>
+        </tr>
+      <%= end %>
+    </table>
+  </div>
+
+
+  <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/web/templates/member/show.html.eex
+++ b/web/templates/member/show.html.eex
@@ -20,6 +20,7 @@
 
   <li>
     <strong>RFID Tokens:</strong>
+    <%= link "Add new RFID token", to: company_member_rfid_token_path(@conn, :new, @company, @member) %>
     <table class="table">
       <tr>
         <th>Identifier</th>
@@ -32,8 +33,18 @@
         </tr>
       <% end %>
     </table>
-    <%= link "Add new RFID token", to: company_member_rfid_token_path(@conn, :new, @company, @member) %>
   </li>
+
+  <%= if length(@member.door_groups) > 0 do %>
+    <li>
+      <strong>Door Groups:</strong>
+      <ul>
+        <%= for door_group <- @member.door_groups do %>
+          <li><%= link door_group.name, to: door_group_path(@conn, :show, door_group) %></li>
+        <% end %>
+      </ul>
+    </li>
+  <% end%>
 
 </ul>
 

--- a/web/views/door_group_view.ex
+++ b/web/views/door_group_view.ex
@@ -1,0 +1,3 @@
+defmodule Gatekeeper.DoorGroupView do
+  use Gatekeeper.Web, :view
+end

--- a/web/views/door_view.ex
+++ b/web/views/door_view.ex
@@ -1,0 +1,3 @@
+defmodule Gatekeeper.DoorView do
+  use Gatekeeper.Web, :view
+end


### PR DESCRIPTION
For the purpose of access control Doors belong to Door Groups.

Right now, Members can have access to Door Groups.

Next up, Companies can have access to Door Groups. If a Member has access to a Door Group directly or via his Company, the door will be allowed to open.

Up for debate is whether to allow direct access to individual Doors at the Member or Company level. I'll probably leave this for later since you can always create a Door Group containing a single door.
- [x] Tests
- [x] Allow companies to be associated with Door Groups
- [x] Show Door Group checkboxes on the Company form
- [x] Show Door Groups on the Company/Show view
- [x] Show Door Group checkboxes on the Member form
- [x] Show Door Groups on the Member/Show view
- [x] Extend door validity check to Company Door Groups
- [x] Show Doors in the Door Group/Show view
