### PR TITLE
Fix double-debs-compile issue for serial

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Gatekeeper.Mixfile do
       {:phoenix_html, "~> 2.3"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
       {:postgrex, ">= 0.0.0"},
-      {:serial, "0.1.1"},
+      {:serial, "0.1.2"},
       {:scrivener, "~> 1.2"},
       {:scrivener_html, "~> 1.1"},
       {:timex, "~> 2.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -33,7 +33,7 @@
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []},
   "scrivener": {:hex, :scrivener, "1.2.1", "4d50f21b5c43cc88d072762584f6e49e206901d7d36007928f156f2e974eec4a", [:mix], [{:ecto, "~> 1.1", [hex: :ecto, optional: false]}, {:postgrex, ">= 0.0.0", [hex: :postgrex, optional: true]}]},
   "scrivener_html": {:hex, :scrivener_html, "1.3.0", "122c96ed1f64273cdef13743aa4adc012d88fe6a9fb2b9919d9fc3a92a02ac52", [:mix], [{:phoenix, "~> 1.0 or ~> 1.2", [hex: :phoenix, optional: true]}, {:phoenix_html, "~> 2.2", [hex: :phoenix_html, optional: false]}, {:scrivener, "~> 1.2 or ~> 2.0.0", [hex: :scrivener, optional: false]}]},
-  "serial": {:hex, :serial, "0.1.1", "6ed1d8ee34fbcf62a2ce0349be0fe25149dc09002390d6200b2f68760fa3b619", [:mix], []},
+  "serial": {:hex, :serial, "0.1.2", "8c0959331417372bf58f259dbc106c59bb7ed482cb3f63f3765150c02cf14b88", [:mix, :make], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "timex": {:hex, :timex, "2.2.1", "0d69012a7fd69f4cbdaa00cc5f2a5f30f1bed56072fb362ed4bddf60db343022", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},


### PR DESCRIPTION
See bitgamma/elixir_serial#8

This breaks tests though because now failures to open the serial port are treated as fatal.  On the other hand, it also addresses #13 
