### PR TITLE
Feature: Cluster

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,9 +35,9 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :gatekeeper, Gatekeeper.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "postgres",
-  password: "postgres",
-  database: "gatekeeper_dev",
-  hostname: "localhost",
+  username: System.get_env("DATABASE_READ_USERNAME") || "postgres",
+  password: System.get_env("DATABASE_READ_PASSWORD") || "postgres",
+  database: System.get_env("DATABASE_READ_DATABASE") || "gatekeeper_dev",
+  hostname: System.get_env("DATABASE_WRITE_HOSTNAME") || "localhost",
   template: "template0",
   pool_size: 10

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -41,3 +41,12 @@ config :gatekeeper, Gatekeeper.Repo,
   hostname: System.get_env("DATABASE_WRITE_HOSTNAME") || "localhost",
   template: "template0",
   pool_size: 10
+
+config :gatekeeper, Gatekeeper.WriteRepo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DATABASE_WRITE_USERNAME"),
+  password: System.get_env("DATABASE_WRITE_PASSWORD"),
+  database: System.get_env("DATABASE_WRITE_DATABASE"),
+  hostname: System.get_env("DATABASE_WRITE_HOSTNAME") || "localhost",
+  template: "template0",
+  pool_size: 10

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -60,7 +60,3 @@ config :gatekeeper, :doorlock,
   gpio_port: '2',
   type: Gpio,
   door_id: 1
-
-# Finally import the config/prod.secret.exs
-# which should be versioned separately.
-import_config "prod.secret.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -60,3 +60,12 @@ config :gatekeeper, :doorlock,
   gpio_port: '2',
   type: Gpio,
   door_id: 1
+
+config :gatekeeper, Gatekeeper.Repo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DATABASE_USERNAME"),
+  password: System.get_env("DATABASE_PASSWORD"),
+  database: System.get_env("DATABASE_DATABASE"),
+  hostname: System.get_env("DATABASE_HOSTNAME") || "localhost",
+  template: "template0",
+  pool_size: 10

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -69,3 +69,12 @@ config :gatekeeper, Gatekeeper.Repo,
   hostname: System.get_env("DATABASE_HOSTNAME") || "localhost",
   template: "template0",
   pool_size: 10
+
+config :gatekeeper, Gatekeeper.WriteRepo,
+  adapter: Ecto.Adapters.Postgres,
+  username: System.get_env("DATABASE_WRITE_USERNAME"),
+  password: System.get_env("DATABASE_WRITE_PASSWORD"),
+  database: System.get_env("DATABASE_WRITE_DATABASE"),
+  hostname: System.get_env("DATABASE_WRITE_HOSTNAME") || "localhost",
+  template: "template0",
+  pool_size: 10

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,4 +21,13 @@ config :gatekeeper, Gatekeeper.Repo,
   template: "template0",
   pool: Ecto.Adapters.SQL.Sandbox
 
+config :gatekeeper, Gatekeeper.WriteRepo,
+  adapter: Ecto.Adapters.Postgres,
+  username: "postgres",
+  password: "postgres",
+  database: "gatekeeper_test",
+  hostname: "localhost",
+  template: "template0",
+  pool: Ecto.Adapters.SQL.Sandbox
+
 System.put_env("GUARDIAN_SECRET_KEY", "abcd")

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,6 +4,7 @@ use Mix.Config
 # you can enable the server option below.
 config :gatekeeper, Gatekeeper.Endpoint,
   http: [port: 4001],
+  secret_key_base: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
   server: false
 
 # Print only warnings and errors during test

--- a/lib/gatekeeper.ex
+++ b/lib/gatekeeper.ex
@@ -9,8 +9,9 @@ defmodule Gatekeeper do
     children = [
       # Start the endpoint when the application starts
       supervisor(Gatekeeper.Endpoint, []),
-      # Start the Ecto repository
-      worker(Gatekeeper.Repo, []),
+      # Start the Ecto repositories
+      worker(Gatekeeper.Repo, []), # local, read-only
+      worker(Gatekeeper.WriteRepo, []), # remote, read-write
       # Here you could define other workers and supervisors as children
       worker(Gatekeeper.DoorInterface, [Application.get_env(:gatekeeper, :doorlock)[:door_id] || 1]),
     ]

--- a/lib/gatekeeper/write_repo.ex
+++ b/lib/gatekeeper/write_repo.ex
@@ -1,3 +1,15 @@
 defmodule Gatekeeper.WriteRepo do
   use Ecto.Repo, otp_app: :gatekeeper
+
+  defmacro __using__(_) do
+    if Mix.env == :test do
+      quote do
+        alias Gatekeeper.Repo, as: WriteRepo
+      end
+    else
+      quote do
+        alias Gatekeeper.WriteRepo
+      end
+    end
+  end
 end

--- a/lib/gatekeeper/write_repo.ex
+++ b/lib/gatekeeper/write_repo.ex
@@ -1,0 +1,3 @@
+defmodule Gatekeeper.WriteRepo do
+  use Ecto.Repo, otp_app: :gatekeeper
+end

--- a/test/controllers/company_controller_test.exs
+++ b/test/controllers/company_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule Gatekeeper.CompanyControllerTest do
   use Gatekeeper.ConnCase
+  use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
 
   import Gatekeeper.Factory
   import Guardian.TestHelper
@@ -43,7 +44,7 @@ defmodule Gatekeeper.CompanyControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    company = Repo.insert! %Company{name: "Company XYZ"}
+    company = WriteRepo.insert! %Company{name: "Company XYZ"}
     conn = get conn, company_path(conn, :show, company)
     assert html_response(conn, 200) =~ "<h2>Company XYZ"
   end
@@ -55,13 +56,13 @@ defmodule Gatekeeper.CompanyControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    company = Repo.insert! %Company{}
+    company = WriteRepo.insert! %Company{}
     conn = get conn, company_path(conn, :edit, company)
     assert html_response(conn, 200) =~ "Edit company"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    company = Repo.insert! %Company{}
+    company = WriteRepo.insert! %Company{}
     conn = put conn, company_path(conn, :update, company), company: @valid_attrs
     assert redirected_to(conn) == company_path(conn, :show, company)
     assert Repo.get_by(Company, @valid_attrs)
@@ -69,7 +70,7 @@ defmodule Gatekeeper.CompanyControllerTest do
 
   test "updates company with associated door groups and redirects when data is valid", %{conn: conn} do
     door_group = create_door_group
-    company = Repo.insert! %Company{}
+    company = WriteRepo.insert! %Company{}
     # We can't dynamically construct a map with a variable without this
     # See: http://stackoverflow.com/questions/29837103/how-to-put-key-value-pair-into-map-with-variable-key-name
     # "Note that variables cannot be used as keys to add items to a map:"
@@ -85,7 +86,7 @@ defmodule Gatekeeper.CompanyControllerTest do
   test "removes unchecked associated door groups from a company", %{conn: conn} do
     door_group = create_door_group
     company = create_company
-    Repo.insert! %Gatekeeper.DoorGroupCompany{company_id: company.id, door_group_id: door_group.id}
+    WriteRepo.insert! %Gatekeeper.DoorGroupCompany{company_id: company.id, door_group_id: door_group.id}
 
     conn = put conn, company_path(conn, :update, company), company: Dict.merge(@valid_attrs, id: company.id)
     assert redirected_to(conn) == company_path(conn, :show, company)
@@ -95,7 +96,7 @@ defmodule Gatekeeper.CompanyControllerTest do
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    company = Repo.insert! %Company{}
+    company = WriteRepo.insert! %Company{}
     conn = put conn, company_path(conn, :update, company), company: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit company"
   end

--- a/test/controllers/door_access_attempt_controller_test.exs
+++ b/test/controllers/door_access_attempt_controller_test.exs
@@ -59,7 +59,7 @@ defmodule Gatekeeper.DoorAccessAttemptControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    door_access_attempt = Repo.insert! %DoorAccessAttempt{}
+    door_access_attempt = WriteRepo.insert! %DoorAccessAttempt{}
     conn = get conn, door_access_attempt_path(conn, :edit, door_access_attempt)
     assert html_response(conn, 200) =~ "Edit door access attempt"
   end
@@ -72,13 +72,13 @@ defmodule Gatekeeper.DoorAccessAttemptControllerTest do
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    door_access_attempt = Repo.insert! %DoorAccessAttempt{}
+    door_access_attempt = WriteRepo.insert! %DoorAccessAttempt{}
     conn = put conn, door_access_attempt_path(conn, :update, door_access_attempt), door_access_attempt: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit door access attempt"
   end
 
   test "deletes chosen resource", %{conn: conn} do
-    door_access_attempt = Repo.insert! %DoorAccessAttempt{}
+    door_access_attempt = WriteRepo.insert! %DoorAccessAttempt{}
     conn = delete conn, door_access_attempt_path(conn, :delete, door_access_attempt)
     assert redirected_to(conn) == door_access_attempt_path(conn, :index)
     refute Repo.get(DoorAccessAttempt, door_access_attempt.id)

--- a/test/controllers/door_controller_test.exs
+++ b/test/controllers/door_controller_test.exs
@@ -45,7 +45,7 @@ defmodule Gatekeeper.DoorControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    door = Repo.insert! %Door{}
+    door = WriteRepo.insert! %Door{}
     conn = get conn, door_path(conn, :show, door)
     assert html_response(conn, 200) =~ "<h1>#{door.name}</h1>"
   end
@@ -57,13 +57,13 @@ defmodule Gatekeeper.DoorControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    door = Repo.insert! %Door{}
+    door = WriteRepo.insert! %Door{}
     conn = get conn, door_path(conn, :edit, door)
     assert html_response(conn, 200) =~ "Edit door"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    door = Repo.insert! %Door{}
+    door = WriteRepo.insert! %Door{}
     conn = put conn, door_path(conn, :update, door), door: @valid_attrs
     assert redirected_to(conn) == door_path(conn, :show, door)
     assert Repo.get_by(Door, @valid_attrs)
@@ -87,7 +87,7 @@ defmodule Gatekeeper.DoorControllerTest do
   test "removes unchecked associated door groups from a company", %{conn: conn} do
     door_group = create_door_group
     door = create_door
-    Repo.insert! %Gatekeeper.DoorGroupDoor{door_id: door.id, door_group_id: door_group.id}
+    WriteRepo.insert! %Gatekeeper.DoorGroupDoor{door_id: door.id, door_group_id: door_group.id}
 
     conn = put conn, door_group_path(conn, :update, door_group), door_group: Dict.merge(@valid_attrs, id: door_group.id)
     assert redirected_to(conn) == door_group_path(conn, :show, door_group)
@@ -97,13 +97,13 @@ defmodule Gatekeeper.DoorControllerTest do
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    door = Repo.insert! %Door{}
+    door = WriteRepo.insert! %Door{}
     conn = put conn, door_path(conn, :update, door), door: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit door"
   end
 
   test "does not delete chosen resource", %{conn: conn} do
-    door = Repo.insert! %Door{}
+    door = WriteRepo.insert! %Door{}
     conn = delete conn, door_path(conn, :delete, door)
     assert redirected_to(conn) == door_path(conn, :index)
     assert Repo.get(Door, door.id)

--- a/test/controllers/door_group_controller_test.exs
+++ b/test/controllers/door_group_controller_test.exs
@@ -44,7 +44,7 @@ defmodule Gatekeeper.DoorGroupControllerTest do
   end
 
   test "shows chosen resource", %{conn: conn} do
-    door_group = Repo.insert! %DoorGroup{name: "Test DG"}
+    door_group = WriteRepo.insert! %DoorGroup{name: "Test DG"}
     conn = get conn, door_group_path(conn, :show, door_group)
     assert html_response(conn, 200) =~ "Door Group: #{door_group.name}"
   end
@@ -56,26 +56,26 @@ defmodule Gatekeeper.DoorGroupControllerTest do
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do
-    door_group = Repo.insert! %DoorGroup{}
+    door_group = WriteRepo.insert! %DoorGroup{}
     conn = get conn, door_group_path(conn, :edit, door_group)
     assert html_response(conn, 200) =~ "Edit door group"
   end
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
-    door_group = Repo.insert! %DoorGroup{}
+    door_group = WriteRepo.insert! %DoorGroup{}
     conn = put conn, door_group_path(conn, :update, door_group), door_group: @valid_attrs
     assert redirected_to(conn) == door_group_path(conn, :show, door_group)
     assert Repo.get_by(DoorGroup, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
-    door_group = Repo.insert! %DoorGroup{}
+    door_group = WriteRepo.insert! %DoorGroup{}
     conn = put conn, door_group_path(conn, :update, door_group), door_group: @invalid_attrs
     assert html_response(conn, 200) =~ "Edit door group"
   end
 
   test "deletes chosen resource", %{conn: conn} do
-    door_group = Repo.insert! %DoorGroup{}
+    door_group = WriteRepo.insert! %DoorGroup{}
     conn = delete conn, door_group_path(conn, :delete, door_group)
     assert redirected_to(conn) == door_group_path(conn, :index)
     refute Repo.get(DoorGroup, door_group.id)

--- a/test/controllers/member_controller_test.exs
+++ b/test/controllers/member_controller_test.exs
@@ -98,7 +98,7 @@ defmodule Gatekeeper.MemberControllerTest do
     door_group = create_door_group
     company = create_company
     member = create_member company: company
-    Repo.insert! %Gatekeeper.DoorGroupCompany{company_id: company.id, door_group_id: door_group.id}
+    WriteRepo.insert! %Gatekeeper.DoorGroupCompany{company_id: company.id, door_group_id: door_group.id}
 
     conn = put conn, company_member_path(conn, :update, company, member), member: Dict.merge(@valid_attrs, id: member.id, company_id: company.id)
     assert redirected_to(conn) == company_member_path(conn, :show, company, member)

--- a/test/controllers/rfid_token_controller_test.exs
+++ b/test/controllers/rfid_token_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule Gatekeeper.RfidTokenControllerTest do
   use Gatekeeper.ConnCase
+  use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
 
   import Gatekeeper.Factory
   import Guardian.TestHelper

--- a/test/factory.exs
+++ b/test/factory.exs
@@ -1,6 +1,7 @@
 defmodule Gatekeeper.Factory do
 
   alias Gatekeeper.Repo
+  use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
   alias Gatekeeper.Company
   alias Gatekeeper.Member
   alias Gatekeeper.RfidToken
@@ -20,11 +21,11 @@ defmodule Gatekeeper.Factory do
     }
     params = Dict.merge(default_params, params)
     changeset = Company.changeset(%Company{}, params)
-    {:ok, company} = Repo.insert(changeset)
+    {:ok, company} = WriteRepo.insert(changeset)
 
     if params[:door_group] do
       changeset = DoorGroupCompany.changeset(%DoorGroupCompany{}, %{company_id: company.id, door_group_id: params.door_group.id})
-      Repo.insert!(changeset)
+      WriteRepo.insert!(changeset)
     end
 
     company
@@ -42,11 +43,11 @@ defmodule Gatekeeper.Factory do
 
     params = Dict.merge(default_params, params)
     changeset = Member.changeset(%Member{}, params)
-    {:ok, member} = Repo.insert(changeset)
+    {:ok, member} = WriteRepo.insert(changeset)
 
     if params[:door_group] do
       changeset = DoorGroupMember.changeset(%DoorGroupMember{}, %{member_id: member.id, door_group_id: params.door_group.id})
-      Repo.insert!(changeset)
+      WriteRepo.insert!(changeset)
     end
 
     member
@@ -63,7 +64,7 @@ defmodule Gatekeeper.Factory do
 
     params = Dict.merge(default_params, params)
     changeset = RfidToken.changeset(%RfidToken{}, params)
-    {:ok, rfid_token} = Repo.insert(changeset)
+    {:ok, rfid_token} = WriteRepo.insert(changeset)
     rfid_token
   end
 
@@ -73,7 +74,7 @@ defmodule Gatekeeper.Factory do
     }
     params = Dict.merge(default_params, params)
     changeset = DoorGroup.changeset(%DoorGroup{}, params)
-    {:ok, door_group} = Repo.insert(changeset)
+    {:ok, door_group} = WriteRepo.insert(changeset)
     door_group
   end
 
@@ -83,11 +84,11 @@ defmodule Gatekeeper.Factory do
     }
     params = Dict.merge(default_params, params)
     changeset = Door.changeset(%Door{}, params)
-    {:ok, door} = Repo.insert(changeset)
+    {:ok, door} = WriteRepo.insert(changeset)
 
     if params[:door_group] do
       changeset = DoorGroupDoor.changeset(%DoorGroupDoor{}, %{door_id: door.id, door_group_id: params.door_group.id})
-      Repo.insert!(changeset)
+      WriteRepo.insert!(changeset)
     end
 
     door
@@ -96,7 +97,7 @@ defmodule Gatekeeper.Factory do
   def create_door_access_attempt(door, rfid_token, params \\ %{}) do
     params = Dict.merge(%{access_allowed: true, door_id: door.id, rfid_token_id: rfid_token.id, reason: "access_allowed"}, params)
     changeset = DoorAccessAttempt.changeset(%DoorAccessAttempt{}, params)
-    {:ok, door_access_attempt} = Repo.insert(changeset)
+    {:ok, door_access_attempt} = WriteRepo.insert(changeset)
     door_access_attempt
   end
 end

--- a/test/models/door_test.exs
+++ b/test/models/door_test.exs
@@ -1,5 +1,6 @@
 defmodule Gatekeeper.DoorTest do
   use Gatekeeper.ModelCase
+  use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
 
   import Gatekeeper.Factory
 

--- a/test/models/rfid_token_test.exs
+++ b/test/models/rfid_token_test.exs
@@ -1,5 +1,6 @@
 defmodule Gatekeeper.RfidTokenTest do
   use Gatekeeper.ModelCase
+  use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
   import Gatekeeper.Factory
 
   alias Gatekeeper.RfidToken
@@ -82,7 +83,7 @@ defmodule Gatekeeper.RfidTokenTest do
     member = create_member company: company
     create_rfid_token member: member, identifier: rfid_token_identifier
     changeset = RfidToken.changeset(%RfidToken{member_id: member.id, identifier: rfid_token_identifier})
-    assert {:error, _message} = Repo.insert changeset
+    assert {:error, _message} = WriteRepo.insert changeset
   end
 
   test "that an RfidToken object is auto-created when an unrecognized badge is scanned" do

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -21,7 +21,8 @@ defmodule Gatekeeper.ChannelCase do
       use Phoenix.ChannelTest
 
       alias Gatekeeper.Repo
-      import Ecto.Model
+      use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
+      import Ecto.Schema
       import Ecto.Query, only: [from: 2]
 
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -21,7 +21,8 @@ defmodule Gatekeeper.ConnCase do
       use Phoenix.ConnTest
 
       alias Gatekeeper.Repo
-      import Ecto.Model
+      use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
+      import Ecto.Schema
       import Ecto.Query, only: [from: 2]
 
       import Gatekeeper.Router.Helpers

--- a/test/support/model_case.ex
+++ b/test/support/model_case.ex
@@ -17,7 +17,8 @@ defmodule Gatekeeper.ModelCase do
   using do
     quote do
       alias Gatekeeper.Repo
-      import Ecto.Model
+      use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
+      import Ecto.Schema
       import Ecto.Query, only: [from: 2]
       import Gatekeeper.ModelCase
     end

--- a/web/controllers/door_access_attempt_controller.ex
+++ b/web/controllers/door_access_attempt_controller.ex
@@ -18,7 +18,7 @@ defmodule Gatekeeper.DoorAccessAttemptController do
   def create(conn, %{"door_access_attempt" => door_access_attempt_params}) do
     changeset = DoorAccessAttempt.changeset(%DoorAccessAttempt{}, door_access_attempt_params)
 
-    case Repo.insert(changeset) do
+    case WriteRepo.insert(changeset) do
       {:ok, _door_access_attempt} ->
         conn
         |> put_flash(:info, "Door access attempt created successfully.")
@@ -43,7 +43,7 @@ defmodule Gatekeeper.DoorAccessAttemptController do
     door_access_attempt = Repo.get!(DoorAccessAttempt, id)
     changeset = DoorAccessAttempt.changeset(door_access_attempt, door_access_attempt_params)
 
-    case Repo.update(changeset) do
+    case WriteRepo.update(changeset) do
       {:ok, door_access_attempt} ->
         conn
         |> put_flash(:info, "Door access attempt updated successfully.")
@@ -58,7 +58,7 @@ defmodule Gatekeeper.DoorAccessAttemptController do
 
     # Here we use delete! (with a bang) because we expect
     # it to always work (and if it does not, it will raise).
-    Repo.delete!(door_access_attempt)
+    WriteRepo.delete!(door_access_attempt)
 
     conn
     |> put_flash(:info, "Door access attempt deleted successfully.")

--- a/web/controllers/door_controller.ex
+++ b/web/controllers/door_controller.ex
@@ -19,7 +19,7 @@ defmodule Gatekeeper.DoorController do
   def create(conn, %{"door" => door_params}) do
     changeset = Door.changeset(%Door{}, door_params)
 
-    case Repo.insert(changeset) do
+    case WriteRepo.insert(changeset) do
       {:ok, _door} ->
         conn
         |> put_flash(:info, "Door created successfully.")
@@ -48,7 +48,7 @@ defmodule Gatekeeper.DoorController do
     door = Repo.get!(Door, id)
     changeset = Door.changeset(door, door_params)
 
-    case Repo.update(changeset) do
+    case WriteRepo.update(changeset) do
       {:ok, door} ->
         conn
         |> put_flash(:info, "Door updated successfully.")

--- a/web/controllers/rfid_token_controller.ex
+++ b/web/controllers/rfid_token_controller.ex
@@ -29,7 +29,7 @@ defmodule Gatekeeper.RfidTokenController do
     member = Repo.get!(Member, member_id) |> Repo.preload(:company) |> Repo.preload(:rfid_tokens)
     changeset = RfidToken.changeset(%RfidToken{member_id: String.to_integer(member_id)}, rfid_token_params)
 
-    case Repo.insert(changeset) do
+    case WriteRepo.insert(changeset) do
       {:ok, _rfid_token} ->
         conn
         |> put_flash(:info, "RFID Token created successfully.")
@@ -74,7 +74,7 @@ defmodule Gatekeeper.RfidTokenController do
 
     changeset = RfidToken.changeset(rfid_token, rfid_token_params)
 
-    case Repo.update(changeset) do
+    case WriteRepo.update(changeset) do
       {:ok, _rfid_token} ->
         if member do
           destination = company_member_path(conn, :show, member.company, member)
@@ -97,7 +97,7 @@ defmodule Gatekeeper.RfidTokenController do
     # Here we use update! (with a bang) because we expect
     # it to always work (and if it does not, it will raise).
     changeset = RfidToken.changeset(rfid_token, %{active: false})
-    Repo.update!(changeset)
+    WriteRepo.update!(changeset)
 
     conn
     |> put_flash(:info, "RFID Token deactivated successfully.")

--- a/web/models/rfid_token.ex
+++ b/web/models/rfid_token.ex
@@ -4,7 +4,7 @@ defmodule Gatekeeper.RfidToken do
   alias Gatekeeper.RfidToken
   alias Gatekeeper.Member
   alias Gatekeeper.Repo
-  alias Gatekeeper.WriteRepo
+  use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
   alias Gatekeeper.Door
   alias Gatekeeper.DoorAccessAttempt
 

--- a/web/models/rfid_token.ex
+++ b/web/models/rfid_token.ex
@@ -4,6 +4,7 @@ defmodule Gatekeeper.RfidToken do
   alias Gatekeeper.RfidToken
   alias Gatekeeper.Member
   alias Gatekeeper.Repo
+  alias Gatekeeper.WriteRepo
   alias Gatekeeper.Door
   alias Gatekeeper.DoorAccessAttempt
 
@@ -76,11 +77,11 @@ defmodule Gatekeeper.RfidToken do
 
   def autocreate_rfid_token(identifier) do
     change = changeset(%Gatekeeper.RfidToken{}, %{identifier: identifier, active: false})
-    Repo.insert! change
+    WriteRepo.insert! change
   end
 
   def create_access_attempt(rfid_token, door, allowed, reason, member_id) do
     changeset = DoorAccessAttempt.changeset(%DoorAccessAttempt{}, %{rfid_token_id: rfid_token.id, door_id: door.id, access_allowed: allowed, reason: reason, member_id: member_id})
-    Repo.insert! changeset
+    WriteRepo.insert! changeset
   end
 end

--- a/web/web.ex
+++ b/web/web.ex
@@ -31,7 +31,7 @@ defmodule Gatekeeper.Web do
       use Phoenix.Controller
 
       alias Gatekeeper.Repo
-      alias Gatekeeper.WriteRepo
+      use Gatekeeper.WriteRepo # allow for hacky override of WriteRepo for tests
       import Ecto
       import Ecto.Query, only: [from: 1, from: 2]
 

--- a/web/web.ex
+++ b/web/web.ex
@@ -31,6 +31,7 @@ defmodule Gatekeeper.Web do
       use Phoenix.Controller
 
       alias Gatekeeper.Repo
+      alias Gatekeeper.WriteRepo
       import Ecto
       import Ecto.Query, only: [from: 1, from: 2]
 


### PR DESCRIPTION
This PR will allow for two roles within the app:
- Controller: The main web UI and system of record for storing app data
- Doors: The devices physically installed at the doors, who pull down/synchronize data from the Controller

There are several changes required to make this happen:
- [x] Allow provisioning to run on x86_64 systems
- [x] Configure PostgreSQL on the Controller role to be a replication master
- [x] Configure PostgreSQL on the Door role to be a replication slave
- [ ] Allow Gatekeeper to run with USB and GPIO disabled on the Controller
- [ ] Allow specifying the Door ID via provisioning
- [x] Split Reads/Writes to separate DB configurations
